### PR TITLE
Updates to reaktoro defaults and inclusion of exclusion options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This option will force Ipopt to use least squares method to calculate dual infea
 
     cy_solver = get_solver(solver="cyipopt-watertap")
     cy_solver.options['recalc_y']='yes'
+    cy_solver.options["recalc_y_feas_tol"] = 1e-2
 
 
 B. Use exact derivatives instead of numeric

--- a/src/reaktoro_pse/core/pyomo_property_writer/property_functions.py
+++ b/src/reaktoro_pse/core/pyomo_property_writer/property_functions.py
@@ -10,6 +10,7 @@
 # "https://github.com/watertap-org/reaktoro-pse/"
 #################################################################################
 from pyomo.environ import log10, log, exp
+from idaes.core.util.math import smooth_max
 
 
 def build_scaling_tendency_constraint(rkt_output_object):
@@ -22,6 +23,12 @@ def build_scaling_tendency_constraint(rkt_output_object):
             ("saturationIndex", rkt_output_object.property_index)
         ].pyomo_var
     )
+
+
+# log10(user_output_var) == smooth_max(
+#     build_properties[("saturationIndex", rkt_output_object.property_index)].pyomo_var,
+#     -5,
+# )
 
 
 def build_ph_constraint(rkt_output_object):

--- a/src/reaktoro_pse/core/reaktoro_block_builder.py
+++ b/src/reaktoro_pse/core/reaktoro_block_builder.py
@@ -218,13 +218,10 @@ class ReaktoroBlockBuilder:
                 return iscale.get_scaling_factor(pyo_var)
 
             sf = calc_scale(abs(pyo_var.value))
-            if sf > 1e10:
+            if sf > 1e16:
                 _log.warning(f"Var {pyo_var} scale {sf}>1e16")
-                sf = 1e10
-            if sf < 1e-10:
+            if sf < 1e-16:
                 _log.warning(f"Var {pyo_var} scale {sf}<1e-16")
-                # sf = 1e-20
-                sf = 1e-10
             return sf
 
     def initialize_output_variables_and_constraints(self):

--- a/src/reaktoro_pse/core/reaktoro_gray_box.py
+++ b/src/reaktoro_pse/core/reaktoro_gray_box.py
@@ -96,7 +96,6 @@ class ReaktoroGrayBox(ExternalGreyBoxModel):
                 self.reaktoro_solver.solve_reaktoro_block(params=new_params)
             )
             self.step += 1
-
         self.old_params = copy.deepcopy(new_params)
 
     def evaluate_jacobian_outputs(self):

--- a/src/reaktoro_pse/core/reaktoro_jacobian.py
+++ b/src/reaktoro_pse/core/reaktoro_jacobian.py
@@ -175,6 +175,13 @@ class JacboianRows:
         return available_dict
 
 
+class ReaktoroJacobianExport:
+    def __init__(self):
+        self.der_step_size = None
+        self.jacobian_type = None
+        self.numerical_order = None
+
+
 class ReaktoroJacobianSpec:
     def __init__(self, reaktor_state, reaktor_outputs):
         self.state = reaktor_state
@@ -188,6 +195,20 @@ class ReaktoroJacobianSpec:
         self.configure_numerical_jacobian()
         self.check_existing_jacobian_props()
 
+    def export_config(self):
+        export_object = ReaktoroJacobianExport()
+        export_object.der_step_size = self.der_step_size
+        export_object.jacobian_type = self.jacobian_type
+        export_object.numerical_order = self.numerical_order
+        return export_object
+
+    def load_from_export_object(self, export_object):
+        self.configure_numerical_jacobian(
+            jacobian_type=export_object.jacobian_type,
+            order=export_object.numerical_order,
+            step_size=export_object.der_step_size,
+        )
+
     def configure_numerical_jacobian(
         self, jacobian_type="average", order=4, step_size=1e-8
     ):
@@ -200,6 +221,7 @@ class ReaktoroJacobianSpec:
         """
         self.der_step_size = step_size
         self.jacobian_type = JacType.average
+        self.numerical_order = order
         if jacobian_type == JacType.average:
             self.jacobian_type = JacType.average
             assert order % 2 == 0

--- a/src/reaktoro_pse/core/reaktoro_outputs.py
+++ b/src/reaktoro_pse/core/reaktoro_outputs.py
@@ -419,7 +419,9 @@ class ReaktoroOutputSpec:
                     pass
 
         raise NotImplementedError(
-            f"The {property_name}, {property_index} is not supported at the moment"
+            f"""The {property_name}, {property_index} was not found,
+                its either not supported, or requested index is not in present.
+            """
         )
 
     def get_possible_indexes(self):

--- a/src/reaktoro_pse/core/reaktoro_outputs.py
+++ b/src/reaktoro_pse/core/reaktoro_outputs.py
@@ -86,7 +86,7 @@ class RktOutput:
         return self.pyomo_var
 
     def set_pyomo_var_value(self, value):
-        self.pyomo_var.value = value
+        self.pyomo_var.set_value(value)
 
     def get_pyomo_var_value(self, value):
         return self.pyomo_var.value
@@ -288,6 +288,7 @@ class ReaktoroOutputSpec:
         property_index=None,
         get_all_indexes=False,
         pyomo_var=None,
+        ignore_indexes=None,
     ):
         """register a reaktoro output, couple it to property type.
 
@@ -298,7 +299,7 @@ class ReaktoroOutputSpec:
         pyomo_var -- pyomo var that should be used for the output of this property (optional: will be auto built) (default: None)
         """
         if get_all_indexes:
-            self.get_all_indexes(property_name)
+            self.get_all_indexes(property_name, ignore_indexes)
         else:
             property_type, get_function = self.get_prop_type(
                 property_name, property_index
@@ -352,25 +353,32 @@ class ReaktoroOutputSpec:
     def get_all_indexes(
         self,
         property_name,
+        ignore_indexes,
     ):
         if "species" in property_name:
             for specie in self.species:
-                property_type, get_function = self.get_prop_type(property_name, specie)
-                self.process_output(
-                    property_type=property_type,
-                    property_name=property_name,
-                    property_index=specie,
-                    get_function=get_function,
-                )
+                if ignore_indexes is None or specie not in str(ignore_indexes):
+                    property_type, get_function = self.get_prop_type(
+                        property_name, specie
+                    )
+                    self.process_output(
+                        property_type=property_type,
+                        property_name=property_name,
+                        property_index=specie,
+                        get_function=get_function,
+                    )
         elif "elements" in property_name:
             for element in self.elements:
-                property_type, get_function = self.get_prop_type(property_name, element)
-                self.process_output(
-                    property_type=property_type,
-                    property_name=property_name,
-                    property_index=element,
-                    get_function=get_function,
-                )
+                if ignore_indexes is None or element not in str(ignore_indexes):
+                    property_type, get_function = self.get_prop_type(
+                        property_name, element
+                    )
+                    self.process_output(
+                        property_type=property_type,
+                        property_name=property_name,
+                        property_index=element,
+                        get_function=get_function,
+                    )
         else:
             raise NotImplementedError(
                 f"{property_name} is not supported for automatic indexing"

--- a/src/reaktoro_pse/core/reaktoro_solver.py
+++ b/src/reaktoro_pse/core/reaktoro_solver.py
@@ -176,11 +176,14 @@ class ReaktoroSolver:
         # here we solve reaktor model and return the jacobian matrix and solution, as
         # Cell as update relevant reaktoroSpecs
         self.update_specs(params)
-
-        result = self.try_solve(presolve)
-        self.outputs = self.get_outputs()
-        self.jacobian_matrix = self.get_jacobian()
-        if result.succeeded() == False or display:
+        solve_failed = False
+        try:
+            result = self.try_solve(presolve)
+            self.outputs = self.get_outputs()
+            self.jacobian_matrix = self.get_jacobian()
+        except RuntimeError:
+            solve_failed = True
+        if solve_failed or result.succeeded() == False or display:
             _log.warning(
                 f"warning, solve was not successful for {self.blockName}, fail# {self._sequential_fails}"
             )

--- a/src/reaktoro_pse/core/reaktoro_solver.py
+++ b/src/reaktoro_pse/core/reaktoro_solver.py
@@ -106,6 +106,7 @@ class ReaktoroSolver:
         self.solver.setOptions(self.solver_options)
         self.hessian_type = hessian_type
         if self.input_specs.assert_charge_neutrality:
+            print("asserting cahrge neturality")
             self.conditions.charge(0)
 
     def set_system_bounds(

--- a/src/reaktoro_pse/core/reaktoro_solver.py
+++ b/src/reaktoro_pse/core/reaktoro_solver.py
@@ -33,6 +33,19 @@ _log = idaeslog.getLogger(__name__)
 # class to setup reaktor solver for reaktoro
 
 
+class ReaktoroSolverExport:
+    def __init__(self):
+        self.epsilon = None
+        self.tolerance = None
+        self.presolve = None
+        self.presolve_tolerance = None
+        self.presolve_epsilon = None
+        self.max_iters = None
+        self.presolve_max_iters = None
+        self.hessian_type = None
+        self.block_name = None
+
+
 class ReaktoroSolver:
     def __init__(
         self,
@@ -42,7 +55,7 @@ class ReaktoroSolver:
         reaktoro_jacobian_specs,
         block_name=None,
     ):
-        self.blockName = block_name
+        self.block_name = block_name
         self.state = reaktoro_state
         if isinstance(self.state, ReaktoroState) == False:
             raise TypeError("Reator jacobian require rektoroState class")
@@ -52,8 +65,8 @@ class ReaktoroSolver:
         self.output_specs = reaktoro_output_specs
         if isinstance(self.output_specs, ReaktoroOutputSpec) == False:
             raise TypeError("Reator outputs require ReaktoroOutputSpec class")
-        self.jacbian_specs = reaktoro_jacobian_specs
-        if isinstance(self.jacbian_specs, ReaktoroJacobianSpec) == False:
+        self.jacobian_specs = reaktoro_jacobian_specs
+        if isinstance(self.jacobian_specs, ReaktoroJacobianSpec) == False:
             raise TypeError("Reator outputs require ReaktoroOutputSpec class")
         self.solver_options = rkt.EquilibriumOptions()
         self.presolve_options = rkt.EquilibriumOptions()
@@ -74,6 +87,34 @@ class ReaktoroSolver:
         self._sequential_fails = 0
         self._max_fails = 30
         self._input_params = {}
+
+    def export_config(self):
+        export_object = ReaktoroSolverExport()
+        export_object.epsilon = self.solver_options.epsilon
+        export_object.tolerance = self.solver_options.optima.convergence.tolerance
+        export_object.presolve = self.presolve
+        export_object.presolve_tolerance = (
+            self.presolve_options.optima.convergence.tolerance
+        )
+        export_object.presolve_epsilon = self.presolve_options.epsilon
+        export_object.max_iters = self.solver_options.optima.maxiters
+        export_object.presolve_max_iters = self.presolve_options.optima.maxiters
+        export_object.hessian_type = self.hessian_type
+        export_object.block_name = self.block_name
+        return export_object
+
+    def load_from_export_object(self, export_object):
+        self.block_name = export_object.block_name
+        self.set_solver_options(
+            export_object.epsilon,
+            export_object.tolerance,
+            export_object.presolve,
+            export_object.presolve_tolerance,
+            export_object.presolve_epsilon,
+            export_object.max_iters,
+            export_object.presolve_max_iters,
+            export_object.hessian_type,
+        )
 
     def set_solver_options(
         self,
@@ -106,7 +147,6 @@ class ReaktoroSolver:
         self.solver.setOptions(self.solver_options)
         self.hessian_type = hessian_type
         if self.input_specs.assert_charge_neutrality:
-            print("asserting cahrge neturality")
             self.conditions.charge(0)
 
     def set_system_bounds(
@@ -131,6 +171,7 @@ class ReaktoroSolver:
             input_obj = self.input_specs.rkt_inputs[input_key]
             if params is None:
                 value = input_obj.get_value(update_temp=True, apply_conversion=True)
+
             else:
                 value = params.get(input_key)
                 input_obj.set_temp_value(value)
@@ -157,11 +198,11 @@ class ReaktoroSolver:
 
     def get_jacobian(self):
         self.tempJacobianMatrix = self.sensitivity.dudw()
-        self.jacbian_specs.update_jacobian_absolute_values()
+        self.jacobian_specs.update_jacobian_absolute_values()
         jac_matrix = []
         for input_key in self.input_specs.rkt_inputs.rkt_input_list:
             input_obj = self.input_specs.rkt_inputs[input_key]
-            jac_row = self.jacbian_specs.get_jacobian(
+            jac_row = self.jacobian_specs.get_jacobian(
                 self.tempJacobianMatrix, input_obj
             )
             jac_matrix.append(jac_row)
@@ -186,7 +227,7 @@ class ReaktoroSolver:
             solve_failed = True
         if solve_failed or result.succeeded() == False or display:
             _log.warning(
-                f"warning, solve was not successful for {self.blockName}, fail# {self._sequential_fails}"
+                f"warning, solve was not successful for {self.block_name}, fail# {self._sequential_fails}"
             )
             _log.warning("----inputs were -----")
             for key, value in self._input_params.items():

--- a/src/reaktoro_pse/core/reaktoro_state.py
+++ b/src/reaktoro_pse/core/reaktoro_state.py
@@ -337,13 +337,17 @@ class ReaktoroState:
         return self.registered_phases[phase]
 
     def process_phase_species(self, phase_type, phases_list):
-        phases = phase_type(rkt.speciate(phases_list))
-        system = rkt.ChemicalSystem(self.database, phases)
-        spc_list = []
-        for specie in system.species():
-            if specie.name() not in str(self.exclude_species_list):
-                spc_list.append(specie.name())
-        return phase_type(" ".join(spc_list)), spc_list
+        if len(phases_list) > 1:
+            phases = phase_type(rkt.speciate(phases_list))
+
+            system = rkt.ChemicalSystem(self.database, phases)
+            spc_list = []
+            for specie in system.species():
+                if specie.name() not in str(self.exclude_species_list):
+                    spc_list.append(specie.name())
+            return phase_type(" ".join(spc_list)), spc_list
+        else:
+            return phase_type(" ".join(phases_list)), phases_list
 
     def register_aqueous_phase(self, aqueous_phases=None):
         """register possible mineral phases"""

--- a/src/reaktoro_pse/core/reaktoro_state.py
+++ b/src/reaktoro_pse/core/reaktoro_state.py
@@ -10,6 +10,7 @@
 # "https://github.com/watertap-org/reaktoro-pse/"
 #################################################################################
 import sys
+from numpy import isin
 import reaktoro as rkt
 from pyomo.environ import units as pyunits
 
@@ -23,9 +24,248 @@ _log = idaeslog.getLogger(__name__)
 __author__ = "Alexander V. Dudchenko"
 
 
+class PhaseData:
+    def __init__(self):
+        """creates state for storing phase object information"""
+        self.phase_list = None
+        self.non_speciate_phase_list = None
+        self.activity_model = None
+        self.state_of_matter = None
+        self.phase_function = None
+        self.phase_list_mode = False
+        self.speciate = True
+
+    def update_species_list(
+        self, species, phase_function, list_mode=False, speciate=True
+    ):
+        """updates list of speciesies for given phase, ensuring no duplication
+
+        args:
+            species - specie or list of specieis to register
+            phase_function - reaktoro function to create phase
+            list_mode - defines if we will need to create a list of phases or single phase
+        """
+
+        def _update_list(current_list, input_val):
+            if isinstance(input_val, str):
+                current_list = [input_val]
+
+            elif isinstance(input_val, list):
+                for i in input_val:
+                    if i not in current_list:
+                        current_list.append(i)
+            else:
+                current_list = input_val
+            return current_list
+
+        if speciate:
+            if species != None and self.phase_list == None:
+                self.phase_list = []
+            self.phase_list = _update_list(self.phase_list, species)
+        else:
+            if species != None and self.non_speciate_phase_list == None:
+                self.non_speciate_phase_list = []
+            self.non_speciate_phase_list = _update_list(
+                self.non_speciate_phase_list, species
+            )
+        self.phase_function = phase_function
+        self.phase_list_mode = list_mode
+
+    def set_activity_model(self, activity_model, state_of_matter=None):
+        """sets activity model and it state"""
+        self.activity_model = activity_model
+        self.state_of_matter = state_of_matter
+
+
+class PhaseManager:
+    def __init__(self):
+        self.registered_phases = {}
+        self.exclude_species_list = []
+
+    def register_phases_species(
+        self, phase, species, phase_function, list_mode=False, speciate=True
+    ):
+        """this is used to add up all phases provided as inputs or registed phases by user,
+        for example, user might provide CO2(g) as a gas input wants to track also N2(g) via register_gas_phase,
+        this ensure we updates all the phases with all requested values
+
+        args:
+            phase - phase type supported by reaktoro-pse
+            species - specie or list of specieis to register
+            phase_function - reaktoro function to create phase
+            list_mode - defines if we will need to create a list of phases or single phase
+        """
+        if phase not in self.registered_phases:
+            self.registered_phases[phase] = PhaseData()
+
+        self.registered_phases[phase].update_species_list(
+            species, phase_function, list_mode, speciate
+        )
+
+    def set_activity_model(
+        self, phase, activity_model, default_activity_model, state_of_matter=None
+    ):
+        """
+        set activity model for reaktoro
+
+        args:
+            phase - phase type supported by reaktoro-pse
+            activity_model - activity model (should be string or touple that contains options
+            to be passed into function)
+            default_activity_model - default activity model if one is not provided
+            state_of_matter - defines state of matter for solids, otherwise none
+        """
+        if phase not in self.registered_phases:
+            self.registered_phases[phase] = PhaseData()
+        if activity_model is None:
+            activity_model = default_activity_model
+        self.registered_phases[phase].set_activity_model(
+            activity_model, state_of_matter
+        )
+
+    def get_registered_phases(self, activate_database):
+        """
+        creates listof phases with applied activity models for generation of reaktoro state
+        args:
+            activate_database - database to use during creation of phases
+
+        """
+
+        activate_phase_list = []
+        for phase, phase_object in self.registered_phases.items():
+            if (
+                phase_object.phase_list is not None
+                or phase_object.non_speciate_phase_list is not None
+            ):
+                rkt_phase_object = self.create_rkt_phase(
+                    activate_database,
+                    phase_object.phase_function,
+                    phase_object.phase_list,
+                    phase_object.non_speciate_phase_list,
+                    phase_object.phase_list_mode,
+                )
+                if isinstance(rkt_phase_object, list):
+                    for rpo in rkt_phase_object:
+                        self.apply_activity_model(
+                            rpo,
+                            phase_object.activity_model,
+                            phase_object.state_of_matter,
+                        )
+                        activate_phase_list.append(rpo)
+                else:
+                    self.apply_activity_model(
+                        rkt_phase_object,
+                        phase_object.activity_model,
+                        phase_object.state_of_matter,
+                    )
+                    activate_phase_list.append(rkt_phase_object)
+        return activate_phase_list
+
+    def apply_activity_model(
+        self, rkt_phase_object, activity_model, state_of_matter=None
+    ):
+        """sets activity mode"""
+        if activity_model is None:
+            raise TypeError(f"Activity model for {rkt_phase_object} is not set.")
+        rkt_activity_model_object = self._process_activity(
+            activity_model, activity_model, state_of_matter
+        )
+        rkt_phase_object.set(rkt_activity_model_object)
+
+    def create_rkt_phase(
+        self,
+        active_database,
+        phase_function,
+        phases_list,
+        non_speciate_phase_list,
+        phase_list_mode,
+    ):
+        """Function to remove species from speciation command"""
+        print("rkt phase", phase_function, phases_list, non_speciate_phase_list)
+        if phase_list_mode:
+            rkt_phase_list = []
+            for phase in phases_list:
+                if isinstance(phase, str):
+                    rkt_phase_list.append(phase_function(phase))
+                else:
+                    rkt_phase_list.append(phase)
+            if non_speciate_phase_list is not None:
+                for phase in non_speciate_phase_list:
+                    if isinstance(phase, str):
+                        rkt_phase_list.append(phase_function(phase))
+                    else:
+                        rkt_phase_list.append(phase)
+            return rkt_phase_list
+        elif isinstance(phases_list, list):
+            if isinstance(phases_list, (list, tuple)):
+                phases_list = " ".join(phases_list)
+            try:
+                # try to spetiatiate
+                phases = phase_function(rkt.speciate(phases_list))
+            except TypeError:
+                # if does nto spectiate, try passing string input directly
+                phases = phase_function(phases_list)
+            system = rkt.ChemicalSystem(active_database, phases)
+            spc_list = []
+            for specie in system.species():
+                if specie.name() not in str(self.exclude_species_list):
+                    spc_list.append(specie.name())
+            if non_speciate_phase_list is not None:
+                for phase in non_speciate_phase_list:
+                    if phase not in spc_list:
+                        spc_list.append(phase)
+            return phase_function(" ".join(spc_list))
+        elif isinstance(non_speciate_phase_list, list):
+            return phase_function(" ".join(non_speciate_phase_list))
+        else:
+            return phases_list
+
+    def _process_activity(
+        self,
+        active_database,
+        activity_model,
+        state_of_matter=None,
+    ):
+        """this will process give activity model if user provides a sting it will
+        find it on reaktoro and initialize it either by it self or passing in state of matter argument
+        if user provides initialized reaktoro activity model we use it directly."""
+        print(activity_model, state_of_matter)
+
+        def get_func(activity_model, state_of_matter):
+            print(activity_model, state_of_matter)
+            if isinstance(activity_model, str):
+                if state_of_matter is None:
+                    try:
+                        return getattr(rkt, activity_model)()
+                    except RuntimeError:
+                        # might require database as input (e.g ActivityModelPhreeqc)
+                        return getattr(rkt, activity_model)(active_database)
+
+                else:
+                    return getattr(rkt, activity_model)(state_of_matter)
+            elif isinstance(activity_model, tuple):
+                if isinstance(activity_model[1], (tuple, list)):
+                    return getattr(rkt, activity_model[0])(*activity_model[1])
+                else:
+                    return getattr(rkt, activity_model[0])(activity_model[1])
+            else:
+                return activity_model
+
+        if isinstance(activity_model, list):
+            if state_of_matter is None:
+                activity_model = rkt.chain(
+                    *[get_func(am, state_of_matter) for am in activity_model]
+                )
+            else:
+                activity_model = rkt.chain(
+                    *[get_func(am, state_of_matter) for am in activity_model]
+                )
+        else:
+            activity_model = get_func(activity_model, state_of_matter)
+        return activity_model
+
+
 # base class for configuring reaktoro states and solver
-
-
 class ReaktoroState:
     def __init__(self):
         """initialize all parameters need to build reaktor solver"""
@@ -33,12 +273,7 @@ class ReaktoroState:
 
         self.mineral_phase = []
         self.solid_phase = []
-        self.liquid_phase = None
-        self.condensed_phase = None
-        self.aqueous_phase = None
-        self.gas_phase = None
-        self.ion_exchange_phase = None
-        self.registered_phases = {}
+        self.phase_manager = PhaseManager()
         self.exclude_species_list = []
 
     def register_system_inputs(
@@ -143,10 +378,10 @@ class ReaktoroState:
         """updates list of species to exclude from when creating phases"""
         if species != None:
             if isinstance(species, str):
-                self.exclude_species_list.append(species)
+                self.phase_manager.exclude_species_list.append(species)
             elif isinstance(species, list):
                 for spc in species:
-                    self.exclude_species_list.append(spc)
+                    self.phase_manager.exclude_species_list.append(spc)
             else:
                 raise TypeError(f"{species} is not supported, must be str or list")
 
@@ -289,138 +524,55 @@ class ReaktoroState:
         else:
             return var
 
-    def _process_phase(self, phase, default_phase):
-        """
-        if phsae is list of speices convert it to single string
-        other wise pass it in directly into phase object
-        if phase object is not list, tuple or str assume its user initialized phase
-        and use directly"""
-        if isinstance(phase, (list, tuple)):
-            return default_phase(" ".join(phase))
-        elif isinstance(phase, str):
-            return default_phase(phase)
-        else:
-            return phase
-
-    def _process_phases(self, phase, default_phase, list_mode=False):
-        # List mode is used for when we expect to build a list of phases, such as Mineral and Solid Phase objects
-        if phase != [] and phase is not None:
-            if isinstance(phase, (str)):
-                phase = [phase]
-            if list_mode:
-                phases = []
-                for p in phase:
-                    phases.append(self._process_phase(p, default_phase))
-                return phases
-            else:
-                return self._process_phase(phase, default_phase)
-        else:
-            return None
-
-    def track_registered_phases(self, phase, inputs):
-        """this is used to add up all phases provided as inputs or registed phases by user,
-        for example, user might provide CO2(g) as a gas input wants to track also N2(g) via register_gas_phase,
-        this ensure we updates all the phases with all requested values"""
-        if inputs is None:
-            return inputs
-        if phase not in self.registered_phases:
-            self.registered_phases[phase] = []
-        if isinstance(self.registered_phases[phase], (str, list)):
-            if isinstance(inputs, str):
-                inputs = [inputs]
-            if isinstance(inputs, list):
-                for i in inputs:
-                    if i not in self.registered_phases[phase]:
-                        self.registered_phases[phase].append(i)
-            else:
-                self.registered_phases[phase] = inputs
-        return self.registered_phases[phase]
-
-    def process_phase_species(self, phase_type, phases_list):
-        if len(phases_list) > 1:
-            phases = phase_type(rkt.speciate(phases_list))
-
-            system = rkt.ChemicalSystem(self.database, phases)
-            spc_list = []
-            for specie in system.species():
-                if specie.name() not in str(self.exclude_species_list):
-                    spc_list.append(specie.name())
-            return phase_type(" ".join(spc_list)), spc_list
-        else:
-            return phase_type(" ".join(phases_list)), phases_list
-
     def register_aqueous_phase(self, aqueous_phases=None):
         """register possible mineral phases"""
         if aqueous_phases != [] and aqueous_phases is not None:
-            if isinstance(aqueous_phases, (list, str)):
-                self.aqueous_phase, aqueous_phases = self.process_phase_species(
-                    rkt.AqueousPhase, aqueous_phases
-                )
-            else:
-                self.aqueous_phase = aqueous_phases
-            aqueous_phases = self.track_registered_phases(
-                RktInputTypes.aqueous_phase, aqueous_phases
+            self.phase_manager.register_phases_species(
+                RktInputTypes.aqueous_phase, aqueous_phases, rkt.AqueousPhase
             )
 
     def register_condensed_phase(self, condensed_phase=None):
         """register possible condensed phases"""
         if condensed_phase != [] and condensed_phase is not None:
-            if isinstance(condensed_phase, (list, str)):
-                self.condensed_phase, condensed_phase = self.process_phase_species(
-                    rkt.CondensedPhases, condensed_phase
-                )
-            else:
-                self.condensed_phase = condensed_phase
-            condensed_phase = self.track_registered_phases(
-                RktInputTypes.condensed_phase, condensed_phase
+            self.phase_manager.register_phases_species(
+                RktInputTypes.condensed_phase, condensed_phase, rkt.CondensedPhases
             )
 
     def register_liquid_phase(self, liquid_phases=None):
         """register possible mineral phases"""
         if liquid_phases != [] and liquid_phases is not None:
-
-            if isinstance(liquid_phases, (list, str)):
-                self.liquid_phase, liquid_phase = self.process_phase_species(
-                    rkt.LiquidPhase, liquid_phase
-                )
-            else:
-                self.liquid_phase = liquid_phases
-            liquid_phases = self.track_registered_phases(
-                RktInputTypes.liquid_phases, liquid_phases
+            self.phase_manager.register_phases_species(
+                RktInputTypes.liquid_phase, liquid_phases, rkt.LiquidPhase
             )
 
     def register_mineral_phases(self, mineral_phases=None):
         """register possible mineral phases"""
-        mineral_phases = self.track_registered_phases(
-            RktInputTypes.mineral_phase, mineral_phases
-        )
-        self.mineral_phase = self._process_phases(
-            mineral_phases, rkt.MineralPhase, list_mode=True
+        self.phase_manager.register_phases_species(
+            RktInputTypes.mineral_phase,
+            mineral_phases,
+            rkt.MineralPhase,
+            list_mode=True,
         )
 
     def register_solid_phases(self, solid_phases=None):
         """register possible solid phases"""
-        solid_phases = self.track_registered_phases(
-            RktInputTypes.solid_phase, solid_phases
-        )
-        self.solid_phase = self._process_phases(
-            solid_phases, rkt.SolidPhase, list_mode=True
+        self.phase_manager.register_phases_species(
+            RktInputTypes.solid_phase, solid_phases, rkt.SolidPhase, list_mode=True
         )
 
-    def register_gas_phase(self, gas_phase=None):
+    def register_gas_phase(self, gas_phase=None, speciate=False):
         """register possible gas phases"""
-        gas_phase = self.track_registered_phases(RktInputTypes.gas_phase, gas_phase)
-        self.gas_phase = self._process_phases(
-            gas_phase, rkt.GaseousPhase, list_mode=False
+        self.phase_manager.register_phases_species(
+            RktInputTypes.gas_phase, gas_phase, rkt.GaseousPhase, speciate=speciate
         )
 
-    def register_ion_exchange_phase(self, ion_exchange_phase=None):
+    def register_ion_exchange_phase(self, ion_exchange_phase=None, speciate=False):
         """register possible ion exchange phases"""
-        ion_exchange_phase = self.track_registered_phases(
-            RktInputTypes.ion_exchange_phase, ion_exchange_phase
-        )
-        self.ion_exchange_phase = self._process_phases(
-            ion_exchange_phase, rkt.IonExchangePhase, list_mode=False
+        self.phase_manager.register_phases_species(
+            RktInputTypes.ion_exchange_phase,
+            ion_exchange_phase,
+            rkt.IonExchangePhase,
+            speciate=speciate,
         )
 
     def set_database(self, dbtype="PhreeqcDatabase", database="pitzer.dat"):
@@ -436,114 +588,71 @@ class ReaktoroState:
             element.symbol() for element in self.database.elements()
         ]
 
-    def _process_activity(
-        self, activity_model, state_of_matter=None, default_activity_model=None
-    ):
-        """this will process give activity model if user provides a strng it will
-        find it on reaktoro and initialize it either by it self or passing in state of matter argument
-        if user provides intialized reaktoro activity model we use it directly."""
-
-        def get_func(activity_model, state_of_matter):
-            if isinstance(activity_model, str):
-                if state_of_matter is None:
-                    return getattr(rkt, activity_model)()
-                else:
-                    return getattr(rkt, activity_model)(state_of_matter)
-            else:
-                return activity_model
-
-        if activity_model is None:
-            activity_model = default_activity_model
-        if isinstance(activity_model, list):
-            if state_of_matter is None:
-                activity_model = rkt.chain(
-                    *[get_func(am, state_of_matter) for am in activity_model]
-                )
-            else:
-                activity_model = rkt.chain(
-                    *[get_func(am, state_of_matter) for am in activity_model]
-                )
-        else:
-            activity_model = get_func(activity_model, state_of_matter)
-        return activity_model
-
     def set_aqueous_phase_activity_model(
         self,
         activity_model=None,
     ):
         """set activity model of aqueous phases in reaktoro"""
-        self.process_registered_inputs()
-        if self.aqueous_phase is not None:
-            activity_model = self._process_activity(
-                activity_model, default_activity_model="ActivityModelIdealAqueous"
-            )
-            self.aqueous_phase.set(activity_model)
+        self.phase_manager.set_activity_model(
+            RktInputTypes.aqueous_phase,
+            activity_model,
+            default_activity_model="ActivityModelIdealAqueous",
+        )
 
     def set_liquid_phase_activity_model(
         self,
         activity_model=None,
     ):
         """set activity model of liquid phases in reaktoro"""
-        self.process_registered_inputs()
-        if self.liquid_phase is not None:
-            activity_model = self._process_activity(
-                activity_model, default_activity_model="ActivityModelIdealSolution"
-            )
-            self.liquid_phase.set(activity_model)
+
+        self.phase_manager.set_activity_model(
+            RktInputTypes.liquid_phase,
+            activity_model,
+            default_activity_model="ActivityModelIdealSolution",
+        )
 
     def set_gas_phase_activity_model(self, activity_model=None):
         """set activity model of gas phases in reaktoro"""
-        self.process_registered_inputs()
-        activity_model = self._process_activity(
-            activity_model, default_activity_model="ActivityModelIdealGas"
+        self.phase_manager.set_activity_model(
+            RktInputTypes.gas_phase,
+            activity_model,
+            default_activity_model="ActivityModelIdealGas",
         )
-        if self.gas_phase is not None:
-            self.gas_phase.set(activity_model)
 
     def set_condensed_phase_activity_model(self, activity_model=None):
         """set activity model of ccondensed phases in reaktoro"""
-        self.process_registered_inputs()
-        activity_model = self._process_activity(
+        self.phase_manager.set_activity_model(
+            RktInputTypes.condensed_phase,
             activity_model,
             default_activity_model="ActivityModelIdealSolution",
             state_of_matter=rkt.StateOfMatter.Liquid,
         )
-        if self.condensed_phase is not None:
-            self.condensed_phase.set(activity_model)
 
     def set_mineral_phase_activity_model(self, activity_model=None):
         """set activity model of mineral phases in reaktoro"""
-        self.process_registered_inputs()
-        activity_model = self._process_activity(
+        self.phase_manager.set_activity_model(
+            RktInputTypes.mineral_phase,
             activity_model,
             state_of_matter=rkt.StateOfMatter.Solid,
             default_activity_model="ActivityModelIdealSolution",
         )
-        if self.mineral_phase is not None:
-            for phase in self.mineral_phase:
-                phase.set(activity_model)
 
     def set_solid_phase_activity_model(self, activity_model=None):
         """set activity model of solid phases in reaktoro"""
-        self.process_registered_inputs()
-        activity_model = self._process_activity(
+        self.phase_manager.set_activity_model(
+            RktInputTypes.solid_phase,
             activity_model,
             state_of_matter=rkt.StateOfMatter.Solid,
             default_activity_model="ActivityModelIdealSolution",
         )
-        if self.solid_phase is not None:
-            for phase in self.solid_phase:
-                phase.set(activity_model)
 
     def set_ion_exchange_phase_activity_model(self, activity_model=None):
         """set activity model of mineral phases in reaktoro"""
-        self.process_registered_inputs()
-        activity_model = self._process_activity(
+        self.phase_manager.set_activity_model(
+            RktInputTypes.ion_exchange_phase,
             activity_model,
             default_activity_model="ActivityModelIonExchange",
         )
-        if self.ion_exchange_phase is not None:
-            self.ion_exchange_phase.set(activity_model)
 
     def process_registered_inputs(self):
         """this will process all inputs, this function must be called before setting activity models!"""
@@ -568,17 +677,14 @@ class ReaktoroState:
             self.register_aqueous_phase(
                 self.inputs.species_list[RktInputTypes.aqueous_phase]
             )
-
         if len(self.inputs.species_list[RktInputTypes.liquid_phase]) > 0:
             self.register_liquid_phase(
                 self.inputs.species_list[RktInputTypes.liquid_phase]
             )
-
         if len(self.inputs.species_list[RktInputTypes.condensed_phase]) > 0:
             self.register_condensed_phase(
                 self.inputs.species_list[RktInputTypes.condensed_phase]
             )
-
         # register gas phases
         if len(self.inputs.species_list[RktInputTypes.mineral_phase]) > 0:
             self.register_mineral_phases(
@@ -599,20 +705,9 @@ class ReaktoroState:
 
     def build_state(self):
         # this will build reaktor states
-        phases = []
-        if self.aqueous_phase is not None:
-            phases.append(self.aqueous_phase)
-        if self.liquid_phase is not None:
-            phases.append(self.liquid_phase)
-        if self.condensed_phase is not None:
-            phases.append(self.condensed_phase)
-        if self.mineral_phase is not None:
-            for m in self.mineral_phase:
-                phases.append(m)
-        if self.gas_phase is not None:
-            phases.append(self.gas_phase)
-        if self.ion_exchange_phase is not None:
-            phases.append(self.ion_exchange_phase)
+        self.process_registered_inputs()
+        phases = self.phase_manager.get_registered_phases(self.database)
+        print(phases)
         self.system = rkt.ChemicalSystem(
             self.database,
             *phases,

--- a/src/reaktoro_pse/core/tests/test_reaktoro_builder.py
+++ b/src/reaktoro_pse/core/tests/test_reaktoro_builder.py
@@ -50,6 +50,7 @@ def build_with_dissolve_in_rkt(build_rkt_state_with_species):
     rkt_inputs.register_chemistry_modifier("CaO", m.lime)
 
     rkt_inputs.configure_specs(dissolve_species_in_rkt=True)
+    rkt_inputs.build_input_specs()
     rkt_outputs = ReaktoroOutputSpec(rkt_state)
     rkt_outputs.register_output("saturationIndex", "Calcite")
     rkt_outputs.register_output("scalingTendency", "Calcite")
@@ -74,6 +75,7 @@ def build_with_dissolve_in_pyomo(build_rkt_state_with_species):
     m.lime.fix()
     rkt_inputs.register_chemistry_modifier("CaO", m.lime)
     rkt_inputs.configure_specs(dissolve_species_in_rkt=False)
+    rkt_inputs.build_input_specs()
     rkt_outputs = ReaktoroOutputSpec(rkt_state)
 
     rkt_outputs.register_output("speciesAmount", get_all_indexes=True)
@@ -97,6 +99,7 @@ def build_with_dissolve_in_rkt_mass_basis(build_rkt_state_with_species_mass_basi
     rkt_inputs.register_chemistry_modifier("CaO", m.lime)
 
     rkt_inputs.configure_specs(dissolve_species_in_rkt=True)
+    rkt_inputs.build_input_specs()
     rkt_outputs = ReaktoroOutputSpec(rkt_state)
     rkt_outputs.register_output("saturationIndex", "Calcite")
     rkt_outputs.register_output("scalingTendency", "Calcite")
@@ -121,6 +124,7 @@ def build_with_dissolve_in_pyomo_mass_basis(build_rkt_state_with_species_mass_ba
     m.lime.fix()
     rkt_inputs.register_chemistry_modifier("CaO", m.lime)
     rkt_inputs.configure_specs(dissolve_species_in_rkt=False)
+    rkt_inputs.build_input_specs()
     rkt_outputs = ReaktoroOutputSpec(rkt_state)
 
     rkt_outputs.register_output("speciesAmount", get_all_indexes=True)

--- a/src/reaktoro_pse/core/tests/test_reaktoro_builder.py
+++ b/src/reaktoro_pse/core/tests/test_reaktoro_builder.py
@@ -141,6 +141,9 @@ def test_build_with_rkt_dissolution(build_with_dissolve_in_rkt):
     m.rkt_block = Block()
     builder = ReaktoroBlockBuilder(m.rkt_block, rkt_solver)
     builder.initialize()
+    m.display()
+    m.rkt_block.reaktoro_model.display()
+    m.rkt_block.output_constraints.pprint()
     # will have as many DOFs as outputs due to pyomo not
     # knowing tha graybox exists.
     assert len(m.rkt_block.reaktoro_model.inputs) == len(

--- a/src/reaktoro_pse/core/tests/test_reaktoro_inputs.py
+++ b/src/reaktoro_pse/core/tests/test_reaktoro_inputs.py
@@ -17,6 +17,7 @@ from reaktoro_pse.core.tests.test_reaktoro_state import (
     build_rkt_state_with_species_no_ph,
 )
 
+import pickle
 
 __author__ = "Alexander V. Dudchenko (SLAC)"
 
@@ -29,6 +30,7 @@ def test_with_rkt_sum(build_rkt_state_with_species):
     rkt_state.equilibrate_state()
     rkt_input = RktInputspec.ReaktoroInputSpec(rkt_state)
     rkt_input.configure_specs(dissolve_species_in_rkt=True)
+    rkt_input.build_input_specs()
     input_names = rkt_input.equilibrium_specs.namesControlVariables()
     print(input_names)
     input_constraints = rkt_input.equilibrium_specs.namesConstraints()
@@ -129,6 +131,7 @@ def test_with_rkt_sum_no_ph(build_rkt_state_with_species_no_ph):
     # rkt_input.register_chemistry_modifier("CaO", lime)
     rkt_input.register_charge_neutrality(False)
     rkt_input.configure_specs(dissolve_species_in_rkt=True)
+    rkt_input.build_input_specs()
     input_names = rkt_input.equilibrium_specs.namesControlVariables()
     input_constraints = rkt_input.equilibrium_specs.namesConstraints()
     print("inputtn", input_names)
@@ -201,6 +204,7 @@ def test_with_pyomo_sum(build_rkt_state_with_species):
     rkt_state.equilibrate_state()
     rkt_input = RktInputspec.ReaktoroInputSpec(rkt_state)
     rkt_input.configure_specs(dissolve_species_in_rkt=False)
+    rkt_input.build_input_specs()
     input_names = rkt_input.equilibrium_specs.namesControlVariables()
     input_constraints = rkt_input.equilibrium_specs.namesConstraints()
     print(input_names)
@@ -293,6 +297,7 @@ def test_with_chemical(build_rkt_state_with_species):
 
     rkt_input.register_chemistry_modifier("CaO", lime)
     rkt_input.configure_specs(dissolve_species_in_rkt=True)
+    rkt_input.build_input_specs()
     expected_con_dict = {
         "C": [(1.0, "CO3-2"), (1.0, "CO2")],
         "Na": [(1, "Na+")],
@@ -314,3 +319,46 @@ def test_with_chemical(build_rkt_state_with_species):
         assert eas in rkt_input.active_species
     assert len(rkt_input.active_species) == len(expected_active_species)
     assert len(rkt_input.constraint_dict) == len(expected_con_dict)
+
+
+def test_input_with_pickle_copy(build_rkt_state_with_species):
+    """testing if we can add chemicals"""
+    m, rkt_state = build_rkt_state_with_species
+    rkt_state.build_state()
+    rkt_state.equilibrate_state()
+    rkt_input = RktInputspec.ReaktoroInputSpec(rkt_state)
+
+    lime = Var(initialize=0.01, units=pyunits.mol / pyunits.s)
+    lime.construct()
+
+    rkt_input.register_chemistry_modifier("CaO", lime)
+    rkt_input.configure_specs(dissolve_species_in_rkt=True)
+    rkt_input.build_input_specs()
+    export_object = rkt_input.export_config()
+    pickled_object = pickle.dumps(export_object)
+    unpickled_object = pickle.loads(pickled_object)
+
+    new_rkt_input = RktInputspec.ReaktoroInputSpec(rkt_state)
+    new_rkt_input.load_from_export_object(unpickled_object)
+    new_rkt_input.build_input_specs()
+    expected_con_dict = {
+        "C": [(1.0, "CO3-2"), (1.0, "CO2")],
+        "Na": [(1, "Na+")],
+        "Ca": [(1, "Ca+2"), (1, "CaO")],
+        "Mg": [(1, "Mg+2")],
+    }
+    expected_active_species = ["CaO", "CO3-2", "CO2", "Na+", "Mg+2", "Ca+2"]
+    print(new_rkt_input.constraint_dict)
+    for ion, ecd in expected_con_dict.items():
+        rkt_ecd = new_rkt_input.constraint_dict[ion]
+        # order might change....
+        expected_ecds = len(ecd)
+        counted_ecds = 0
+        for i, (mol, ion) in enumerate(ecd):
+            if mol == rkt_ecd[i][0] and ion == rkt_ecd[i][1]:
+                counted_ecds += 1
+        assert counted_ecds == expected_ecds
+    for eas in expected_active_species:
+        assert eas in new_rkt_input.active_species
+    assert len(new_rkt_input.active_species) == len(expected_active_species)
+    assert len(new_rkt_input.constraint_dict) == len(expected_con_dict)

--- a/src/reaktoro_pse/core/tests/test_reaktoro_jacobian.py
+++ b/src/reaktoro_pse/core/tests/test_reaktoro_jacobian.py
@@ -29,6 +29,7 @@ __author__ = "Alexander V. Dudchenko (SLAC)"
 def build_standard_state(build_rkt_state_with_species):
     m, rkt_state = build_rkt_state_with_species
     rkt_state.register_mineral_phases("Calcite")
+    rkt_state.set_mineral_phase_activity_model()
     rkt_state.build_state()
     rkt_state.equilibrate_state()
     rkt_outputs = ReaktoroOutputSpec(rkt_state)

--- a/src/reaktoro_pse/core/tests/test_reaktoro_solver.py
+++ b/src/reaktoro_pse/core/tests/test_reaktoro_solver.py
@@ -9,7 +9,14 @@
 # information, respectively. These files are also available online at the URL
 # "https://github.com/watertap-org/reaktoro-pse/"
 #################################################################################
+import enum
+from matplotlib.font_manager import json_load
 import pytest
+
+from reaktoro_pse.core import reaktoro_jacobian
+from reaktoro_pse.core.reaktoro_state import (
+    ReaktoroState,
+)
 from reaktoro_pse.core.reaktoro_jacobian import (
     ReaktoroJacobianSpec,
 )
@@ -26,6 +33,7 @@ from reaktoro_pse.core.reaktoro_solver import (
 from reaktoro_pse.core.tests.test_reaktoro_state import (
     build_rkt_state_with_species,
 )
+import pickle
 
 __author__ = "Alexander V. Dudchenko (SLAC)"
 
@@ -39,6 +47,7 @@ def build_standard_state(build_rkt_state_with_species):
     rkt_state.equilibrate_state()
     rkt_inputs = ReaktoroInputSpec(rkt_state)
     rkt_inputs.configure_specs(dissolve_species_in_rkt=True)
+    rkt_inputs.build_input_specs()
     rkt_outputs = ReaktoroOutputSpec(rkt_state)
 
     rkt_outputs.register_output("speciesAmount", get_all_indexes=True)
@@ -55,6 +64,269 @@ def test_solver(build_standard_state):
     rkt_outputs = list(rkt_solver.output_specs.rkt_outputs.keys())
     print(rkt_inputs, rkt_outputs)
     jacobian, outputs = rkt_solver.solve_reaktoro_block()
+    print(rkt_solver.input_specs.constraint_dict)
+    print(outputs)
+
+    print([list(l) for l in jacobian])
+    expected_jacboian = [
+        [
+            7.65801494995876e-29,
+            -3.2593494210913563e-36,
+            -2.0741686517690312e-07,
+            -1.2444007911747241e-25,
+            -1.2444007911747241e-25,
+            -6.59081971194882e-25,
+            -4.207269823736039e-25,
+            -1.49021692379296e-25,
+            1.8015999999999957e-09,
+        ],
+        [
+            1.0164395367051604e-20,
+            6.866245319043687e-27,
+            -4.336808689942018e-19,
+            0.0,
+            0.0,
+            7.572474548453445e-18,
+            2.021901526413905e-16,
+            3.608224830031759e-16,
+            1.0000000000000002,
+        ],
+        [
+            8.113696485592391e-09,
+            2.259849376471579e-14,
+            1.8969408354645065e-06,
+            0.00018499351646543246,
+            0.00018499351646543246,
+            -5.365768096869442e-09,
+            -2.079524546710911e-07,
+            -0.00018499351646543243,
+            2.1465127438467364e-08,
+        ],
+        [
+            -2.2978260821996717e-05,
+            -3.5929224848216754e-12,
+            -0.0022255415992898475,
+            0.10861973878704173,
+            0.10861973878704173,
+            2.5854592687684853e-05,
+            -7.862397271260802e-05,
+            -0.1086197387870417,
+            1.2228659892086806e-05,
+        ],
+        [
+            -6.97588777427779e-05,
+            1.752980296255229e-11,
+            -0.004359091473550756,
+            -0.4251074388881366,
+            -0.4251074388881366,
+            1.23303128504726e-05,
+            0.00047786612798534213,
+            0.4251074388881366,
+            6.417220061052413e-05,
+        ],
+        [
+            -9.506954286039246e-05,
+            1.2343205845216623e-11,
+            -0.0067549379919742926,
+            -1.332845072372407,
+            -1.332845072372407,
+            1.0000387004805447,
+            1.9993273694083085,
+            1.332845072372407,
+            7.666185878716834e-05,
+        ],
+        [
+            -4.902071817094089e-05,
+            1.9528117516004683e-11,
+            -0.002301278845038802,
+            0.44991531783507444,
+            0.44991531783507444,
+            -1.3049869556825355e-05,
+            -0.0005057528313723928,
+            -0.44991531783507444,
+            5.220447623445768e-05,
+        ],
+        [
+            -2.319471918733151e-06,
+            -1.5705239528364755e-12,
+            -0.000168062223965199,
+            -0.01617237731406427,
+            -0.01617237731406427,
+            5.078063204763274e-07,
+            0.9989279156972547,
+            0.01617237731406427,
+            2.8189443979070547e-07,
+        ],
+        [
+            2.2319875536741277e-06,
+            1.5720094376045971e-12,
+            0.0001658320299424294,
+            0.016172510973281984,
+            0.016172510973281984,
+            -4.6904451234755533e-07,
+            0.0010624508845250356,
+            -0.016172510973281984,
+            -2.824006434580601e-07,
+        ],
+        [
+            8.748436505902249e-08,
+            -1.4854847681209652e-15,
+            2.2301940227696188e-06,
+            -1.3365921772339677e-07,
+            -1.3365921772339677e-07,
+            -3.876180812891046e-08,
+            9.633418220193148e-06,
+            1.3365921772339675e-07,
+            5.062036675536108e-10,
+        ],
+        [
+            -4.2305648105828074e-23,
+            2.1210189671414445e-28,
+            7.711300019601966e-21,
+            -3.607486416211351e-18,
+            -3.607486416211351e-18,
+            1.0,
+            4.975628662739501e-19,
+            3.469447455833694e-18,
+            2.8879777636005514e-18,
+        ],
+        [
+            4.818680399137594e-09,
+            5.521859127979695e-16,
+            1.3833746784683956e-07,
+            1.4407827958482247e-09,
+            1.4407827958482247e-09,
+            -2.402918241875753e-09,
+            -3.603326006163468e-09,
+            -1.4407827958482247e-09,
+            1.2326277977217798e-09,
+        ],
+        [
+            6.975887774277788e-05,
+            -1.7529802962552286e-11,
+            0.004359091473550756,
+            0.4251074388881365,
+            0.4251074388881365,
+            -1.2330312850461427e-05,
+            -0.0004778661279853019,
+            0.5748925611118636,
+            -6.417220061052484e-05,
+        ],
+        [
+            -8.844850965738781e-18,
+            -6.482170044637456e-13,
+            0.0,
+            -2.592868017854982e-05,
+            -0.0001296434008927491,
+            -5.185736035709962e-07,
+            0.0,
+            2.5928680178549815e-05,
+            -8.271806125530277e-25,
+        ],
+        [0.0, 0.0, 1.0000000002666605, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ]
+    for i, jrow in enumerate(expected_jacboian):
+        for k, jval in enumerate(jrow):
+            assert pytest.approx(jval, 1e-3) == jacobian[i][k]
+
+    expected_input_names = [
+        "temperature",
+        "pressure",
+        "pH",
+        "CO3-2",
+        "CO2",
+        "Na",
+        "Mg",
+        "Ca",
+        "H2O",
+    ]
+    for i, ein in enumerate(expected_input_names):
+        assert ein in rkt_inputs[i]
+    assert len(expected_input_names) == len(rkt_inputs)
+    expected_output_keys = [
+        ("speciesAmount", "H+"),
+        ("speciesAmount", "H2O"),
+        ("speciesAmount", "CO3-2"),
+        ("speciesAmount", "CO2"),
+        ("speciesAmount", "Ca+2"),
+        ("speciesAmount", "Cl-"),
+        ("speciesAmount", "HCO3-"),
+        ("speciesAmount", "Mg+2"),
+        ("speciesAmount", "MgCO3"),
+        ("speciesAmount", "MgOH+"),
+        ("speciesAmount", "Na+"),
+        ("speciesAmount", "OH-"),
+        ("speciesAmount", "Calcite"),
+        ("saturationIndex", "Calcite"),
+        ("pH", None),
+    ]
+    for i, eon in enumerate(expected_output_keys):
+        assert eon == rkt_outputs[i]
+    assert len(expected_output_keys) == len(rkt_outputs)
+    expected_output_values = [
+        9.00799999999998e-08,
+        50.0,
+        1.2347717588732544e-06,
+        0.0007251176324639623,
+        0.0028374543608618453,
+        0.7024523350480891,
+        0.0030030389116422994,
+        0.09989096781756118,
+        0.00010806304499670852,
+        9.69137442114817e-07,
+        0.5,
+        6.007103894733061e-08,
+        0.007162545639138155,
+        -5.1857360357099634e-15,
+        7.0,
+    ]
+    for i, eov in enumerate(expected_output_values):
+        assert pytest.approx(eov, 1e-3) == outputs[i]
+    assert len(expected_output_values) == len(outputs)
+
+    expected_jac_shape = (len(expected_output_keys), len(expected_input_names))
+    assert jacobian.shape[0] == expected_jac_shape[0]
+    assert jacobian.shape[1] == expected_jac_shape[1]
+
+
+def test_pickled_solver(build_standard_state):
+    old_rkt_solver = build_standard_state
+    export_state = old_rkt_solver.state.export_config()
+    export_inputs = old_rkt_solver.input_specs.export_config()
+    export_outputs = old_rkt_solver.output_specs.export_config()
+    export_jac = old_rkt_solver.jacobian_specs.export_config()
+    export_solver = old_rkt_solver.export_config()
+
+    export_data = [
+        export_state,
+        export_inputs,
+        export_outputs,
+        export_jac,
+        export_solver,
+    ]
+    pickled_epxort = pickle.dumps(export_data)
+    unpickeld_export = pickle.loads(pickled_epxort)
+
+    rkt_state = ReaktoroState()
+    rkt_state.load_from_export_object(unpickeld_export[0])
+    rkt_state.build_state()
+    rkt_state.equilibrate_state()
+    rkt_inputs = ReaktoroInputSpec(rkt_state)
+    rkt_inputs.load_from_export_object(unpickeld_export[1])
+    rkt_inputs.build_input_specs()
+    print(rkt_inputs.constraint_dict)
+    rkt_outputs = ReaktoroOutputSpec(rkt_state)
+    rkt_outputs.load_from_export_object(unpickeld_export[2])
+    rkt_jacobian = ReaktoroJacobianSpec(rkt_state, rkt_outputs)
+    rkt_jacobian.load_from_export_object(unpickeld_export[3])
+    rkt_solver = ReaktoroSolver(rkt_state, rkt_inputs, rkt_outputs, rkt_jacobian)
+    rkt_solver.load_from_export_object(unpickeld_export[4])
+
+    rkt_inputs = rkt_solver.input_specs.rkt_inputs.rkt_input_list
+    rkt_outputs = list(rkt_solver.output_specs.rkt_outputs.keys())
+
+    jacobian, outputs = rkt_solver.solve_reaktoro_block()
+    print(rkt_solver.state.state)
     print(outputs)
     expected_input_names = [
         "temperature",
@@ -114,3 +386,163 @@ def test_solver(build_standard_state):
     expected_jac_shape = (len(expected_output_keys), len(expected_input_names))
     assert jacobian.shape[0] == expected_jac_shape[0]
     assert jacobian.shape[1] == expected_jac_shape[1]
+    expected_jacboian = [
+        [
+            7.65801494995876e-29,
+            -3.2593494210913563e-36,
+            -2.0741686517690312e-07,
+            -1.2444007911747241e-25,
+            -1.2444007911747241e-25,
+            -6.59081971194882e-25,
+            -4.207269823736039e-25,
+            -1.49021692379296e-25,
+            1.8015999999999957e-09,
+        ],
+        [
+            1.0164395367051604e-20,
+            6.866245319043687e-27,
+            -4.336808689942018e-19,
+            0.0,
+            0.0,
+            7.572474548453445e-18,
+            2.021901526413905e-16,
+            3.608224830031759e-16,
+            1.0000000000000002,
+        ],
+        [
+            8.113696485592391e-09,
+            2.259849376471579e-14,
+            1.8969408354645065e-06,
+            0.00018499351646543246,
+            0.00018499351646543246,
+            -5.365768096869442e-09,
+            -2.079524546710911e-07,
+            -0.00018499351646543243,
+            2.1465127438467364e-08,
+        ],
+        [
+            -2.2978260821996717e-05,
+            -3.5929224848216754e-12,
+            -0.0022255415992898475,
+            0.10861973878704173,
+            0.10861973878704173,
+            2.5854592687684853e-05,
+            -7.862397271260802e-05,
+            -0.1086197387870417,
+            1.2228659892086806e-05,
+        ],
+        [
+            -6.97588777427779e-05,
+            1.752980296255229e-11,
+            -0.004359091473550756,
+            -0.4251074388881366,
+            -0.4251074388881366,
+            1.23303128504726e-05,
+            0.00047786612798534213,
+            0.4251074388881366,
+            6.417220061052413e-05,
+        ],
+        [
+            -9.506954286039246e-05,
+            1.2343205845216623e-11,
+            -0.0067549379919742926,
+            -1.332845072372407,
+            -1.332845072372407,
+            1.0000387004805447,
+            1.9993273694083085,
+            1.332845072372407,
+            7.666185878716834e-05,
+        ],
+        [
+            -4.902071817094089e-05,
+            1.9528117516004683e-11,
+            -0.002301278845038802,
+            0.44991531783507444,
+            0.44991531783507444,
+            -1.3049869556825355e-05,
+            -0.0005057528313723928,
+            -0.44991531783507444,
+            5.220447623445768e-05,
+        ],
+        [
+            -2.319471918733151e-06,
+            -1.5705239528364755e-12,
+            -0.000168062223965199,
+            -0.01617237731406427,
+            -0.01617237731406427,
+            5.078063204763274e-07,
+            0.9989279156972547,
+            0.01617237731406427,
+            2.8189443979070547e-07,
+        ],
+        [
+            2.2319875536741277e-06,
+            1.5720094376045971e-12,
+            0.0001658320299424294,
+            0.016172510973281984,
+            0.016172510973281984,
+            -4.6904451234755533e-07,
+            0.0010624508845250356,
+            -0.016172510973281984,
+            -2.824006434580601e-07,
+        ],
+        [
+            8.748436505902249e-08,
+            -1.4854847681209652e-15,
+            2.2301940227696188e-06,
+            -1.3365921772339677e-07,
+            -1.3365921772339677e-07,
+            -3.876180812891046e-08,
+            9.633418220193148e-06,
+            1.3365921772339675e-07,
+            5.062036675536108e-10,
+        ],
+        [
+            -4.2305648105828074e-23,
+            2.1210189671414445e-28,
+            7.711300019601966e-21,
+            -3.607486416211351e-18,
+            -3.607486416211351e-18,
+            1.0,
+            4.975628662739501e-19,
+            3.469447455833694e-18,
+            2.8879777636005514e-18,
+        ],
+        [
+            4.818680399137594e-09,
+            5.521859127979695e-16,
+            1.3833746784683956e-07,
+            1.4407827958482247e-09,
+            1.4407827958482247e-09,
+            -2.402918241875753e-09,
+            -3.603326006163468e-09,
+            -1.4407827958482247e-09,
+            1.2326277977217798e-09,
+        ],
+        [
+            6.975887774277788e-05,
+            -1.7529802962552286e-11,
+            0.004359091473550756,
+            0.4251074388881365,
+            0.4251074388881365,
+            -1.2330312850461427e-05,
+            -0.0004778661279853019,
+            0.5748925611118636,
+            -6.417220061052484e-05,
+        ],
+        [
+            -8.844850965738781e-18,
+            -6.482170044637456e-13,
+            0.0,
+            -2.592868017854982e-05,
+            -0.0001296434008927491,
+            -5.185736035709962e-07,
+            0.0,
+            2.5928680178549815e-05,
+            -8.271806125530277e-25,
+        ],
+        [0.0, 0.0, 1.0000000002666605, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ]
+    for i, jrow in enumerate(expected_jacboian):
+        for k, jval in enumerate(jrow):
+            assert pytest.approx(jval, 1e-3) == jacobian[i][k]

--- a/src/reaktoro_pse/core/tests/test_reaktoro_solver.py
+++ b/src/reaktoro_pse/core/tests/test_reaktoro_solver.py
@@ -34,6 +34,7 @@ __author__ = "Alexander V. Dudchenko (SLAC)"
 def build_standard_state(build_rkt_state_with_species):
     m, rkt_state = build_rkt_state_with_species
     rkt_state.register_mineral_phases("Calcite")
+    rkt_state.set_mineral_phase_activity_model()
     rkt_state.build_state()
     rkt_state.equilibrate_state()
     rkt_inputs = ReaktoroInputSpec(rkt_state)

--- a/src/reaktoro_pse/core/util_classes/rkt_inputs.py
+++ b/src/reaktoro_pse/core/util_classes/rkt_inputs.py
@@ -168,7 +168,7 @@ class RktInput:
         return self.rkt_index
 
     def set_pyomo_var_value(self, value):
-        self.pyomo_var.value = value
+        self.pyomo_var.set_value(value)
 
     def get_pyomo_var_value(self):
         return self.pyomo_var.value

--- a/src/reaktoro_pse/core/util_classes/rkt_inputs.py
+++ b/src/reaktoro_pse/core/util_classes/rkt_inputs.py
@@ -275,12 +275,9 @@ def specie_to_rkt_species(species):
     # TODO: needs to be better automated
     name_dict = {
         "-2": ["SO4", "CO3"],
-        "-": [
-            "Cl",
-            "HCO3",
-        ],
+        "-": ["Cl", "HCO3", "F"],
         "+": ["Na", "K"],
-        "+2": ["Mg", "Ca", "Sr", "Ba"],
+        "+2": ["Mg", "Mn", "Ca", "Sr", "Ba"],
         "": ["H2O", "CO2"],
         "H4SiO4": ["Si", "SiO2"],
     }

--- a/src/reaktoro_pse/examples/biogas_combustion.py
+++ b/src/reaktoro_pse/examples/biogas_combustion.py
@@ -23,6 +23,7 @@ from pyomo.util.calc_var_value import calculate_variable_from_constraint
 import idaes.core.util.scaling as iscale
 import reaktoro as rkt
 
+__author__ = "Alexander V. Dudchenko"
 
 # This examples demonstrates how Reaktoro graybox can be used to estimates combustion perofrming an optimization
 # on following reaktoro example: https://reaktoro.org/applications/biomass-gasification/biomass-gasification.html

--- a/src/reaktoro_pse/examples/biogas_combustion.py
+++ b/src/reaktoro_pse/examples/biogas_combustion.py
@@ -129,9 +129,8 @@ def build_biogas(open_species=False):
         gas_phase={
             "composition": m.air,
             "convert_to_rkt_species": False,
-            "phase_components": rkt.GaseousPhase(
-                rkt.speciate("C H O N")
-            ),  # Expects all possible gasses
+            "phase_components": "C H O N",  # Expects all possible gasses
+            "speciate_phase_component": True,
         },
         system_state={
             "pressure": m.feed_pressure,

--- a/src/reaktoro_pse/examples/simple_desalination.py
+++ b/src/reaktoro_pse/examples/simple_desalination.py
@@ -26,6 +26,7 @@ import idaes.core.util.scaling as iscale
 
 
 import reaktoro as rkt
+
 __author__ = "Alexander V. Dudchenko"
 
 # This examples demonstrates how Reaktoro graybox can be used to estimates

--- a/src/reaktoro_pse/examples/simple_desalination.py
+++ b/src/reaktoro_pse/examples/simple_desalination.py
@@ -26,7 +26,7 @@ import idaes.core.util.scaling as iscale
 
 
 import reaktoro as rkt
-
+__author__ = "Alexander V. Dudchenko"
 
 # This examples demonstrates how Reaktoro graybox can be used to estimates
 # properties in desalination process.

--- a/src/reaktoro_pse/examples/simple_ion_exchange.py
+++ b/src/reaktoro_pse/examples/simple_ion_exchange.py
@@ -25,8 +25,7 @@ import idaes.core.util.scaling as iscale
 import pyomo.environ as pyo
 import reaktoro as rkt
 
-from reaktoro_pse.reaktoro_block_config import jacobian_options
-
+__author__ = "Alexander V. Dudchenko"
 
 # This examples demonstrates how Reaktoro graybox can be used to estimates removal of specific ion through use of ion exchange material.
 

--- a/src/reaktoro_pse/examples/tests/test_examples.py
+++ b/src/reaktoro_pse/examples/tests/test_examples.py
@@ -20,6 +20,7 @@ from reaktoro_pse.examples import (
 
 def test_desal():
     m, m_open = simple_desalination.main()
+
     assert (
         pytest.approx(m.desal_properties[("scalingTendency", "Gypsum")].value, 1e-3)
         == 0.604051223942643

--- a/src/reaktoro_pse/examples/thermal_precipitation.py
+++ b/src/reaktoro_pse/examples/thermal_precipitation.py
@@ -65,7 +65,7 @@ def build_simple_precipitation():
     m.feed_composition["H2O"].fix(55)
     m.feed_composition["Mg"].fix(0.01)
     m.feed_composition["Na"].fix(0.025)
-    m.feed_composition["Cl"].fix(0.025)
+    m.feed_composition["Cl"].fix(0.03)
     m.feed_composition["Ca"].fix(0.002)
     m.feed_composition["HCO3"].fix(0.01)
     m.feed_composition["SO4"].fix(0.02)

--- a/src/reaktoro_pse/examples/thermal_precipitation.py
+++ b/src/reaktoro_pse/examples/thermal_precipitation.py
@@ -24,6 +24,7 @@ from pyomo.util.calc_var_value import calculate_variable_from_constraint
 import reaktoro
 import idaes.core.util.scaling as iscale
 
+__author__ = "Alexander V. Dudchenko"
 
 # This examples demonstrates how reaktoro graybox can be used to enthalpy and water vapor pressure.
 

--- a/src/reaktoro_pse/reaktoro_block.py
+++ b/src/reaktoro_pse/reaktoro_block.py
@@ -91,7 +91,7 @@ class ReaktoroBlockData(ProcessBlockData):
         ),
     )
     CONFIG.declare(
-        "speciation_block_species_ignore",
+        "speciation_block_exclude_species",
         ConfigValue(
             default=None,
             domain=list,
@@ -587,11 +587,11 @@ class ReaktoroBlockData(ProcessBlockData):
             raise ValueError("Outputs must be provided!")
         if speciation_block:
             # when speciating we only want species amounts as output
-            if self.config.speciation_block_species_ignore is not None:
+            if self.config.speciation_block_exclude_species is not None:
                 block.rkt_outputs.register_output(
                     "speciesAmount",
                     get_all_indexes=True,
-                    ignore_indexes=self.config.speciation_block_species_ignore,
+                    ignore_indexes=self.config.speciation_block_exclude_species,
                 )
             else:
                 block.rkt_outputs.register_output("speciesAmount", get_all_indexes=True)

--- a/src/reaktoro_pse/reaktoro_block.py
+++ b/src/reaktoro_pse/reaktoro_block.py
@@ -577,6 +577,7 @@ class ReaktoroBlockData(ProcessBlockData):
                 dissolve_species_in_rkt=self.config.dissolve_species_in_reaktoro,
                 exact_speciation=True,
             )
+        block.rkt_inputs.build_input_specs()
 
     def build_rkt_outputs(self, block, speciation_block=False):
         """this will build rkt outputs specified block.

--- a/src/reaktoro_pse/reaktoro_block.py
+++ b/src/reaktoro_pse/reaktoro_block.py
@@ -61,7 +61,10 @@ class ReaktoroBlockData(ProcessBlockData):
             include_pH=True, aqueous_phase=False, include_solvent_species=True
         ),
     )
-    CONFIG.declare(RktInputTypes.gas_phase, PhaseInput().get_dict())
+    CONFIG.declare(
+        RktInputTypes.gas_phase,
+        PhaseInput().get_dict(include_speciate_phase_component=True),
+    )
     CONFIG.declare(RktInputTypes.condensed_phase, PhaseInput().get_dict())
     CONFIG.declare(RktInputTypes.mineral_phase, PhaseInput().get_dict())
     CONFIG.declare(RktInputTypes.solid_phase, PhaseInput().get_dict())
@@ -349,7 +352,9 @@ class ReaktoroBlockData(ProcessBlockData):
                 building_prop_block_after_speciation()
                 and getattr(self.config, phase_type).phase_components is None
             ):
-                return getattr(self.speciation_block.rkt_state, phase_type)
+                return self.speciation_block.rkt_state.phase_manager.registered_phases[
+                    phase_type
+                ].phase_list
             else:
                 return getattr(self.config, phase_type).phase_components
 
@@ -461,8 +466,12 @@ class ReaktoroBlockData(ProcessBlockData):
             block.rkt_state.register_aqueous_phase(get_phases("aqueous_phase"))
             block.rkt_state.register_liquid_phase(get_phases("liquid_phase"))
             block.rkt_state.register_solid_phases(get_phases("solid_phase"))
-            block.rkt_state.register_condensed_phase(get_phases("condensed_phase"))
-            block.rkt_state.register_gas_phase(get_phases("gas_phase"))
+            block.rkt_state.register_condensed_phase(
+                get_phases("condensed_phase"),
+            )
+            block.rkt_state.register_gas_phase(
+                get_phases("gas_phase"), self.config.gas_phase.speciate_phase_component
+            )
             block.rkt_state.register_mineral_phases(get_phases("mineral_phase"))
             block.rkt_state.register_ion_exchange_phase(
                 get_phases("ion_exchange_phase")

--- a/src/reaktoro_pse/reaktoro_block.py
+++ b/src/reaktoro_pse/reaktoro_block.py
@@ -561,7 +561,7 @@ class ReaktoroBlockData(ProcessBlockData):
             # if we have built a speciation block, the feed should be charge neutral and
             # exact speciation is provided
             block.rkt_inputs.register_charge_neutrality(
-                assert_neutrality=True, ion="H+"  # self.config.charge_neutrality_ion
+                assert_neutrality=False, ion=self.config.charge_neutrality_ion
             )
 
             block.rkt_inputs.configure_specs(

--- a/src/reaktoro_pse/reaktoro_block.py
+++ b/src/reaktoro_pse/reaktoro_block.py
@@ -85,9 +85,10 @@ class ReaktoroBlockData(ProcessBlockData):
             default=None,
             domain=list,
             description="List of species to not include in output of speciation block and input into property block",
-            doc="""If enabled, will construct a speciation block to calculate initial equilibrium state 
-             at specified pH. Any chemicals will be added to the property block, enable this when exact composition is unknown and the 
-             property state is modified through addition of chemicals or formation of phases that modify final state""",
+            doc="""If provided then selected species will not be passed from speciation block and into property block. 
+            This is useful for removing species that do not go above 0 and cause issues during solve. No warning or checks
+            are performed by Reaktoro-PSE for scenario where the given species is above 0 at any time during solve. The user
+            should manually verify that the specie did not go above 0 or expected value. """,
         ),
     )
     CONFIG.declare(

--- a/src/reaktoro_pse/reaktoro_block.py
+++ b/src/reaktoro_pse/reaktoro_block.py
@@ -80,6 +80,17 @@ class ReaktoroBlockData(ProcessBlockData):
         ),
     )
     CONFIG.declare(
+        "exclude_species_list",
+        ConfigValue(
+            default=None,
+            domain=list,
+            description="List of species to exclude from speciation in reaktoro",
+            doc="""The species that should not be included when speciating aqueous, liquid, or condensed phases, this 
+            will completely exclude the species from thermodynamic speciation. This is not the same as
+            rkt.exclude. """,
+        ),
+    )
+    CONFIG.declare(
         "speciation_block_species_ignore",
         ConfigValue(
             default=None,
@@ -406,6 +417,7 @@ class ReaktoroBlockData(ProcessBlockData):
                 )
         else:
             aqueous_input_composition = self.config.aqueous_phase.composition
+        block.rkt_state.register_species_to_exclude(self.config.exclude_species_list)
 
         block.rkt_state.register_aqueous_inputs(
             composition=aqueous_input_composition,
@@ -549,7 +561,7 @@ class ReaktoroBlockData(ProcessBlockData):
             # if we have built a speciation block, the feed should be charge neutral and
             # exact speciation is provided
             block.rkt_inputs.register_charge_neutrality(
-                assert_neutrality=False, ion=self.config.charge_neutrality_ion
+                assert_neutrality=True, ion="H+"  # self.config.charge_neutrality_ion
             )
 
             block.rkt_inputs.configure_specs(

--- a/src/reaktoro_pse/reaktoro_block_config/input_options.py
+++ b/src/reaktoro_pse/reaktoro_block_config/input_options.py
@@ -7,7 +7,11 @@ class PhaseInput:
         pass
 
     def get_dict(
-        self, include_pH=False, aqueous_phase=False, include_solvent_species=False
+        self,
+        include_pH=False,
+        aqueous_phase=False,
+        include_solvent_species=False,
+        include_speciate_phase_component=False,
     ):
         phase_input = ConfigDict()
         phase_input.declare(
@@ -44,6 +48,20 @@ class PhaseInput:
             """,
             ),
         )
+        if include_speciate_phase_component:
+            phase_input.declare(
+                "speciate_phase_component",
+                ConfigValue(
+                    default=False,
+                    description="To speciate specified phases",
+                    doc="""
+                        Use this to speciate give specie or elements to all possible
+                        phases or elements
+                        
+                        Works only on 
+                        Gas phase""",
+                ),
+            )
         phase_input.declare(
             "convert_to_rkt_species",
             ConfigValue(

--- a/src/reaktoro_pse/reaktoro_block_config/jacobian_options.py
+++ b/src/reaktoro_pse/reaktoro_block_config/jacobian_options.py
@@ -30,7 +30,7 @@ class JacobianOptions:
         CONFIG.declare(
             "numerical_order",
             ConfigValue(
-                default=8,
+                default=10,
                 domain=int,
                 description="Defines order of numerical jacobian (should be an even number)",
                 doc="""
@@ -43,7 +43,7 @@ class JacobianOptions:
         CONFIG.declare(
             "numerical_step",
             ConfigValue(
-                default=1e-5,
+                default=5e-3,
                 domain=float,
                 description="Defines the step to use for numerical descritiazaiton",
                 doc="""This will define how small of a step to use for numerical derivative propagation which takes
@@ -85,11 +85,11 @@ class JacobianOptions:
         CONFIG.declare(
             "hessian_type",
             ConfigValue(
-                default="BFGS",
+                default="BFGS-ipopt",
                 domain=IsInstance((str, HessTypes)),
                 description="Hessian type to use for reaktor gray box",
                 doc="""Hessian type to use, some might provide better stability
-                options (Jt.J, BFGS, BFGS-mod,BFGS-damp, BFGS-ipopt""",
+                options (Jt.J, BFGS, BFGS-mod, BFGS-damp, BFGS-ipopt""",
             ),
         )
         return CONFIG

--- a/src/reaktoro_pse/reaktoro_block_config/jacobian_options.py
+++ b/src/reaktoro_pse/reaktoro_block_config/jacobian_options.py
@@ -85,7 +85,7 @@ class JacobianOptions:
         CONFIG.declare(
             "hessian_type",
             ConfigValue(
-                default="BFGS-ipopt",
+                default="BFGS",
                 domain=IsInstance((str, HessTypes)),
                 description="Hessian type to use for reaktor gray box",
                 doc="""Hessian type to use, some might provide better stability

--- a/src/reaktoro_pse/tests/test_reaktoro_block.py
+++ b/src/reaktoro_pse/tests/test_reaktoro_block.py
@@ -237,7 +237,7 @@ def test_blockBuild_with_speciation_block(build_rkt_state_with_species):
             pytest.approx(scaling_result["speciation_block"][key], 1e-3)
             == expected_scaling["speciation_block"][key]
         )
-    m.property_block.set_jacobian_scaling(new_scaling)
+    m.property_block.update_jacobian_scaling(new_scaling)
     new_scaling = {}
     for key in scaling_result["property_block"]:
         new_scaling[key] = 1
@@ -245,7 +245,7 @@ def test_blockBuild_with_speciation_block(build_rkt_state_with_species):
             pytest.approx(scaling_result["property_block"][key], 1e-3)
             == expected_scaling["property_block"][key]
         )
-    m.property_block.set_jacobian_scaling(new_scaling)
+    m.property_block.update_jacobian_scaling(new_scaling)
     scaling_result = m.property_block.display_jacobian_scaling()
     assert "speciation_block" in scaling_result
     assert "property_block" in scaling_result

--- a/src/reaktoro_pse/tests/test_reaktoro_block.py
+++ b/src/reaktoro_pse/tests/test_reaktoro_block.py
@@ -238,6 +238,11 @@ def test_blockBuild_with_speciation_block(build_rkt_state_with_species):
             == expected_scaling["speciation_block"][key]
         )
     m.property_block.update_jacobian_scaling(new_scaling)
+    scaling_result = m.property_block.display_jacobian_scaling()
+
+    assert "speciation_block" in scaling_result
+    for key in scaling_result["speciation_block"]:
+        assert scaling_result["speciation_block"][key] == 1
     new_scaling = {}
     for key in scaling_result["property_block"]:
         new_scaling[key] = 1
@@ -247,10 +252,8 @@ def test_blockBuild_with_speciation_block(build_rkt_state_with_species):
         )
     m.property_block.update_jacobian_scaling(new_scaling)
     scaling_result = m.property_block.display_jacobian_scaling()
-    assert "speciation_block" in scaling_result
+
     assert "property_block" in scaling_result
-    for key in scaling_result["speciation_block"]:
-        assert scaling_result["speciation_block"][key] == 1
     for key in scaling_result["property_block"]:
         assert scaling_result["property_block"][key] == 1
 

--- a/src/reaktoro_pse/tutorials/basic_reaktoro_block_interaction.ipynb
+++ b/src/reaktoro_pse/tutorials/basic_reaktoro_block_interaction.ipynb
@@ -233,6 +233,7 @@
    "outputs": [],
    "source": [
     "\"\"\"Ions\"\"\"\n",
+    "\n",
     "ions = list(sea_water_composition.keys())\n",
     "\n",
     "\"\"\"Ions concentration variable\"\"\"\n",
@@ -259,6 +260,7 @@
    "outputs": [],
    "source": [
     "\"\"\"Charge neutrality\"\"\"\n",
+    "\n",
     "m.fs.sea_water.charge = Var(initialize=0)\n",
     "set_scaling_factor(m.fs.sea_water.charge, 1e8)\n",
     "\n",
@@ -362,7 +364,7 @@
     "        \"fixed_solvent_specie\": \"H2O\",  # We need to define our aqueous solvent as we have to speciate the block\n",
     "    },\n",
     "    outputs=m.fs.sea_water.outputs,  # outputs we desired\n",
-    "    database='PhreeqcDatabase', #can also be reaktoro.PhreeqcDatabase('pitzer.dat')\n",
+    "    database=\"PhreeqcDatabase\",  # can also be reaktoro.PhreeqcDatabase('pitzer.dat')\n",
     "    database_file=\"pitzer.dat\",  # needs to be a string that names the database file or points to its location\n",
     "    dissolve_species_in_reaktoro=True,  # This will sum up all species into elements in Reaktoro directly, if set to false, it will build Pyomo constraints instead\n",
     "    assert_charge_neutrality=False,  # This is True by Default, but here we actually want to adjust the input speciation till the charge is zero\n",
@@ -1058,7 +1060,7 @@
     "print(\"Sea water pH: \", m.fs.sea_water.pH.value)\n",
     "print(\"Reaktoro block outputs\")\n",
     "for key, obj in m.fs.modified_sea_water.outputs.items():\n",
-    "    print(key, obj.value) "
+    "    print(key, obj.value)"
    ]
   },
   {
@@ -1543,12 +1545,13 @@
    ],
    "source": [
     "\"\"\"Increase feed concentration\"\"\"\n",
+    "\n",
     "for ion, pyo_obj in m.fs.sea_water.species_concentrations.items():\n",
-    "    if ion!='Cl':\n",
-    "        pyo_obj.fix(pyo_obj.value*10)\n",
+    "    if ion != \"Cl\":\n",
+    "        pyo_obj.fix(pyo_obj.value * 10)\n",
     "\n",
     "m.fs.modified_sea_water.pH.unfix()\n",
-    "m.fs.modified_sea_water.outputs['scalingTendency','Calcite'].fix(1)\n",
+    "m.fs.modified_sea_water.outputs[\"scalingTendency\", \"Calcite\"].fix(1)\n",
     "m.fs.sea_water.species_concentrations.display()\n",
     "\n",
     "cy_solver = get_solver(solver=\"cyipopt-watertap\")\n",

--- a/src/reaktoro_pse/tutorials/integration_with_ro.ipynb
+++ b/src/reaktoro_pse/tutorials/integration_with_ro.ipynb
@@ -689,7 +689,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.fs.feed.reaktoro_properties.set_jacobian_scaling({(\"density\", None): 1000})"
+    "m.fs.feed.reaktoro_properties.update_jacobian_scaling({(\"density\", None): 1000})"
    ]
   },
   {


### PR DESCRIPTION
This adds new options to exclude species and new defaults for numerical derivatives that hopefully will help with stability and dual infeasiblity options. This also adds options to export state configs for use in multiprocessing implementation. 

The exclusion options are as follows:
```
    CONFIG.declare(
        "exclude_species_list",
        ConfigValue(
            default=None,
            domain=list,
            description="List of species to exclude from speciation in reaktoro",
            doc="""The species that should not be included when speciating aqueous, liquid, or condensed phases, this 
            will completely exclude the species from thermodynamic speciation. This is not the same as
            rkt.exclude. """,
        ),
    )
    CONFIG.declare(
        "speciation_block_exclude_species",
        ConfigValue(
            default=None,
            domain=list,
            description="List of species to not include in output of speciation block and input into property block",
            doc="""If provided then selected species will not be passed from speciation block and into property block. 
            This is useful for removing species that do not go above 0 and cause issues during solve. No warning or checks
            are performed by Reaktoro-PSE for scenario where the given species is above 0 at any time during solve. The user
            should manually verify that the specie did not go above 0 or expected value. """,
        ),
    )
```