### PR TITLE
Add option to define number of failed solves inside ipopt

### DIFF
--- a/src/reaktoro_pse/core/reaktoro_solver.py
+++ b/src/reaktoro_pse/core/reaktoro_solver.py
@@ -54,6 +54,7 @@ class ReaktoroSolver:
         reaktoro_output_specs,
         reaktoro_jacobian_specs,
         block_name=None,
+        maximum_failed_solves=2,
     ):
         self.block_name = block_name
         self.state = reaktoro_state
@@ -85,7 +86,7 @@ class ReaktoroSolver:
         self.set_solver_options()
         self.set_system_bounds()
         self._sequential_fails = 0
-        self._max_fails = 30
+        self._max_fails = maximum_failed_solves
         self._input_params = {}
         self.jacobian_scaling_values = None
 

--- a/src/reaktoro_pse/reaktoro_block.py
+++ b/src/reaktoro_pse/reaktoro_block.py
@@ -260,6 +260,7 @@ class ReaktoroBlockData(ProcessBlockData):
             before doing any initialization calls, or interacting with ReaktoroBlocks themself .""",
         ),
     )
+
     CONFIG.declare("jacobian_options", JacobianOptions().get_dict())
 
     CONFIG.declare(
@@ -696,6 +697,7 @@ class ReaktoroBlockData(ProcessBlockData):
             block.rkt_outputs,
             block.rkt_jacobian,
             block_name=name,
+            maximum_failed_solves=self.config.reaktoro_solve_options.max_reaktoro_failed_solves,
         )
         block.rkt_solver.set_system_bounds(
             self.config.system_state.temperature_bounds,

--- a/src/reaktoro_pse/reaktoro_block_config/reaktoro_solver_options.py
+++ b/src/reaktoro_pse/reaktoro_block_config/reaktoro_solver_options.py
@@ -35,6 +35,16 @@ class ReaktoroSolverOptions:
                 doc="""The maximum number of iterations for Reaktoro solver""",
             ),
         )
+        CONFIG.declare(
+            "max_reaktoro_failed_solves",
+            ConfigValue(
+                default=2,
+                domain=int,
+                description="Number of attempts to re-solve Reaktoro block when running inside a solver",
+                doc="""Defines number of tries Reaktoro block can fail to solve when running inside solver. When Reaktoro fails
+                it will raise CyIpoptEvaluationError, this defines how many sequential raises are allowed before terminating.""",
+            ),
+        )
         if presolve_options:
             CONFIG.declare(
                 "presolve_during_initialization",


### PR DESCRIPTION
This PR will expose the option to change how many  times Reaktoro would be resolved inside CyIpopt. 