### PR TITLE
Add option to provide a modified system state to property block

### DIFF
--- a/src/reaktoro_pse/core/util_classes/rkt_inputs.py
+++ b/src/reaktoro_pse/core/util_classes/rkt_inputs.py
@@ -29,6 +29,7 @@ class RktInputTypes:
     dimensionless = "dimensionless"
     mass_units = ["kg", "mg"]
     system_state = "system_state"
+    system_state_modifier='system_state_modifier'
     aqueous_phase = "aqueous_phase"
     gas_phase = "gas_phase"
     mineral_phase = "mineral_phase"

--- a/src/reaktoro_pse/core/util_classes/rkt_inputs.py
+++ b/src/reaktoro_pse/core/util_classes/rkt_inputs.py
@@ -29,7 +29,7 @@ class RktInputTypes:
     dimensionless = "dimensionless"
     mass_units = ["kg", "mg"]
     system_state = "system_state"
-    system_state_modifier='system_state_modifier'
+    system_state_modifier = "system_state_modifier"
     aqueous_phase = "aqueous_phase"
     gas_phase = "gas_phase"
     mineral_phase = "mineral_phase"

--- a/src/reaktoro_pse/reaktoro_block_config/input_options.py
+++ b/src/reaktoro_pse/reaktoro_block_config/input_options.py
@@ -154,7 +154,7 @@ class SystemInput:
     def __init__(self):
         pass
 
-    def get_dict(self):
+    def get_dict(self, enable_pH=True):
         system_input = ConfigDict()
         system_input.declare(
             "temperature",
@@ -216,26 +216,27 @@ class SystemInput:
                     - If false, all indexed blocks will get same input""",
             ),
         )
-        system_input.declare(
-            "pH",
-            ConfigValue(
-                default=None,
-                domain=IsInstance((VarData, Var, dict, IndexedVar)),
-                description="Input pH for reaktoro block",
-                doc="Var or IndexedVar that references system pH",
-            ),
-        )
-        system_input.declare(
-            "pH_indexed",
-            ConfigValue(
-                default=True,
-                domain=bool,
-                description="pH is indexed",
-                doc="""Option that defines how to treat input variable when building indexed reaktoroBlock":
-                - If true, the input has same indexing as block, and each indexed input will be passed into respective indexed reaktoroBlock
-                - If false, all indexed blocks will get same input""",
-            ),
-        )
+        if enable_pH:
+            system_input.declare(
+                "pH",
+                ConfigValue(
+                    default=None,
+                    domain=IsInstance((VarData, Var, dict, IndexedVar)),
+                    description="Input pH for reaktoro block",
+                    doc="Var or IndexedVar that references system pH",
+                ),
+            )
+            system_input.declare(
+                "pH_indexed",
+                ConfigValue(
+                    default=True,
+                    domain=bool,
+                    description="pH is indexed",
+                    doc="""Option that defines how to treat input variable when building indexed reaktoroBlock":
+                    - If true, the input has same indexing as block, and each indexed input will be passed into respective indexed reaktoroBlock
+                    - If false, all indexed blocks will get same input""",
+                ),
+            )
         system_input.declare(
             "temperature_bounds",
             ConfigValue(

--- a/src/reaktoro_pse/tutorials/basic_reaktoro_block_interaction.ipynb
+++ b/src/reaktoro_pse/tutorials/basic_reaktoro_block_interaction.ipynb
@@ -691,7 +691,7 @@
    ],
    "source": [
     "print(\"DOFs:\", degrees_of_freedom(m))\n",
-    "assert degrees_of_freedom(m)  == 0"
+    "assert degrees_of_freedom(m) == 0"
    ]
   },
   {

--- a/src/reaktoro_pse/tutorials/integration_with_ro.ipynb
+++ b/src/reaktoro_pse/tutorials/integration_with_ro.ipynb
@@ -831,7 +831,7 @@
    ],
    "source": [
     "print(\"DOFs:\", degrees_of_freedom(m))\n",
-    "assert degrees_of_freedom(m)== 0"
+    "assert degrees_of_freedom(m) == 0"
    ]
   },
   {


### PR DESCRIPTION
Currently there is no way for user to provide options to change a pH in property block (build_speciation_block=True option), similar to chemistry_modifier. This pr adds option to provide a system_state_modifier that can include changes in temperature and pressure, allowing simple modeling of systems where a original composition is heated, or goes through a pressure change event. 
